### PR TITLE
Silverstripe 6 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
 		"issues": "http://github.com/evanshunt/lumberjack-sort-and-summary/issues"
 	},
 	"require": {
-		"silverstripe/framework": "^5",
-        "silverstripe/cms": "^5",
-        "silverstripe/lumberjack": "^3"
+		"silverstripe/framework": "^6",
+        "silverstripe/cms": "^6",
+        "silverstripe/lumberjack": "^4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/LumberjackSortAndSummaryExtension.php
+++ b/src/LumberjackSortAndSummaryExtension.php
@@ -5,12 +5,13 @@ namespace EvansHunt\LumberjackSortAndSummary;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Lumberjack\Model\Lumberjack;
+use SilverStripe\ORM\DataList;
 
 class LumberjackSortAndSummaryExtension extends Lumberjack
 {
-    
+
     // this will use $summary_fields and $default_sort of the provided class
-    public function getLumberjackPagesForGridField($excluded = [])
+    public function getLumberjackPagesForGridField($excluded = []): DataList
     {
         $childClasses = $this->getChildClassesOtherThanSiteTree();
 
@@ -18,7 +19,7 @@ class LumberjackSortAndSummaryExtension extends Lumberjack
             $className = $childClasses[0];
             return $className::get()->filter(
                 [
-                    'ParentID' => $this->owner->ID,
+                    'ParentID' => $this->getOwner()->ID,
                     'ClassName' => $excluded,
                 ]
             );
@@ -27,7 +28,7 @@ class LumberjackSortAndSummaryExtension extends Lumberjack
     }
 
     // this will change the tab title
-    public function getLumberJackTitle()
+    public function getLumberJackTitle(): string
     {
         $childClasses = $this->getChildClassesOtherThanSiteTree();
 
@@ -37,11 +38,12 @@ class LumberjackSortAndSummaryExtension extends Lumberjack
         return parent::getLumberjackTitle();
     }
 
-    private function getChildClassesOtherThanSiteTree()
+    private function getChildClassesOtherThanSiteTree(): array
     {
         $childClasses = Config::inst()->get(get_class($this->owner), 'allowed_children');
         return array_values(array_filter($childClasses, function ($className) {
             return $className !== SiteTree::class;
         }));
     }
+
 }


### PR DESCRIPTION
Updated Composer dependencies to CMS6 versions.

Also added return typehints and used the recommended `getOwner()` function instead of accessing the `owner` property